### PR TITLE
Back-propagated: AN-4321

### DIFF
--- a/unpackaged/main/default/classes/UpdatePortalDiscount_FailingTests.cls
+++ b/unpackaged/main/default/classes/UpdatePortalDiscount_FailingTests.cls
@@ -1,0 +1,14 @@
+@isTest
+public class UpdatePortalDiscount_FailingTests {
+
+    @isTest static void test1() {
+    
+    
+         System.assertEquals(2, 1);
+         
+    }
+    
+    @isTest static void test2() {
+        System.assertEquals(1, 2);
+    }
+}

--- a/unpackaged/main/default/classes/UpdatePortalDiscount_FailingTests.cls-meta.xml
+++ b/unpackaged/main/default/classes/UpdatePortalDiscount_FailingTests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>42.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/unpackaged/main/default/classes/UpdatePortalDiscount_PassingTests.cls
+++ b/unpackaged/main/default/classes/UpdatePortalDiscount_PassingTests.cls
@@ -1,0 +1,11 @@
+@isTest
+public class UpdatePortalDiscount_PassingTests {
+
+    @isTest static void test1() {
+         System.assertEquals(1, 1);
+    }
+    
+    @isTest static void test2() {
+        System.assertEquals(2, 2);
+    }
+}

--- a/unpackaged/main/default/classes/UpdatePortalDiscount_PassingTests.cls-meta.xml
+++ b/unpackaged/main/default/classes/UpdatePortalDiscount_PassingTests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/unpackaged/main/default/flows/Closed_Won_Opportunities.flow-meta.xml
+++ b/unpackaged/main/default/flows/Closed_Won_Opportunities.flow-meta.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <areMetricsLoggedToDataCloud>false</areMetricsLoggedToDataCloud>
+    <description>If a high-value opportunity is closed and won, create a draft contract.</description>
+    <environments>Default</environments>
+    <interviewLabel>Closed Won Opportunities {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Closed Won Opportunities</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordCreates>
+        <description>Create a draft contract when an opportunity is won and is over 25,000</description>
+        <name>Create_Draft_Contract</name>
+        <label>Create Draft Contract</label>
+        <locationX>176</locationX>
+        <locationY>335</locationY>
+        <inputAssignments>
+            <field>AccountId</field>
+            <value>
+                <elementReference>$Record.Account.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <inputAssignments>
+            <field>Status</field>
+            <value>
+                <stringValue>Draft</stringValue>
+            </value>
+        </inputAssignments>
+        <object>Contract</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <start>
+        <locationX>50</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Create_Draft_Contract</targetReference>
+        </connector>
+        <doesRequireRecordChangedToMeetCriteria>true</doesRequireRecordChangedToMeetCriteria>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>StageName</field>
+            <operator>EqualTo</operator>
+            <value>
+                <stringValue>Closed Won</stringValue>
+            </value>
+        </filters>
+        <filters>
+            <field>Amount</field>
+            <operator>GreaterThan</operator>
+            <value>
+                <numberValue>25000.0</numberValue>
+            </value>
+        </filters>
+        <object>Opportunity</object>
+        <recordTriggerType>CreateAndUpdate</recordTriggerType>
+        <triggerType>RecordAfterSave</triggerType>
+    </start>
+    <status>Active</status>
+</Flow>

--- a/unpackaged/main/default/objects/Address/fields/Address.field-meta.xml
+++ b/unpackaged/main/default/objects/Address/fields/Address.field-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Address</fullName>
+    <trackHistory>false</trackHistory>
+</CustomField>


### PR DESCRIPTION
## What has changed?
- Added two new Apex test classes: `UpdatePortalDiscount_FailingTests.cls` and `UpdatePortalDiscount_PassingTests.cls`.
- Introduced a new auto-launched Flow `Closed_Won_Opportunities.flow-meta.xml` that creates a draft contract when an Opportunity is closed won and amount exceeds 25,000.
- Added a new custom field `Address` on the `Address` object.

## What's the impact of these changes?
- The Flow automates contract creation for high-value closed won Opportunities, improving process efficiency.
- New test classes provide both passing and failing test scenarios, useful for validation or demonstration.
- Addition of the `Address` field may impact integrations, layouts, or reports referencing the `Address` object.

## What should reviewers pay attention to?
- Validate the Flow's trigger criteria and record creation logic for correctness and potential bulk processing issues.
- Review the purpose and usage of the failing test class to ensure it does not affect deployment or CI pipelines.
- Confirm the new `Address` field metadata is complete and correctly configured.

## Testing recommendations
- Manual testing of the Flow by creating Opportunities with varying amounts and stage changes to verify draft contract creation.
- Review unit test classes:
  - `UpdatePortalDiscount_FailingTests` ❌ (contains failing asserts)
  - `UpdatePortalDiscount_PassingTests` ✅
- Regression testing on Opportunity and Contract objects to ensure no unintended side effects from the Flow or new field addition.